### PR TITLE
fix(dart): remove redirect to end session end point on signout

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -99,7 +99,7 @@ class _MyHomePageState extends State<MyHomePage> {
         textStyle: const TextStyle(fontSize: 20),
       ),
       onPressed: () async {
-        await logtoClient.signOut(redirectUri: redirectUri);
+        await logtoClient.signOut();
         render();
       },
       child: const Text('Sign Out'),

--- a/lib/logto_client.dart
+++ b/lib/logto_client.dart
@@ -186,25 +186,7 @@ class LogtoClient {
         }
       }
 
-      final postLogoutRedirectUri =
-          redirectUri == null ? null : Uri.parse(redirectUri);
-
-      final signOutUri = logto_core.generateSignOutUri(
-        endSessionEndpoint: oidcConfig.endSessionEndpoint,
-        idToken: idToken.serialization,
-        postLogoutRedirectUri: postLogoutRedirectUri,
-      );
-
       await _tokenStorage.clear();
-
-      if (postLogoutRedirectUri != null) {
-        await FlutterWebAuth.authenticate(
-          url: signOutUri.toString(),
-          callbackUrlScheme: postLogoutRedirectUri.scheme,
-        );
-      } else {
-        await httpClient.get(signOutUri);
-      }
     } finally {
       if (_httpClient == null) {
         httpClient.close();

--- a/lib/logto_client.dart
+++ b/lib/logto_client.dart
@@ -69,12 +69,7 @@ class LogtoClient {
 
   bool _loading = false;
 
-  Future<void> signIn(
-    String redirectUri, {
-    Color? primaryColor,
-    Color? backgroundColor,
-    Widget? title,
-  }) async {
+  Future<void> signIn(String redirectUri) async {
     if (_loading) throw Exception('Already signing in...');
     final httpClient = _httpClient ?? http.Client();
 
@@ -154,9 +149,7 @@ class LogtoClient {
     );
   }
 
-  Future<void> signOut({
-    String? redirectUri,
-  }) async {
+  Future<void> signOut() async {
     // Throw error is authentication status not found
     final idToken = await _tokenStorage.idToken;
 

--- a/lib/logto_client.dart
+++ b/lib/logto_client.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_web_auth/flutter_web_auth.dart';
 import 'package:http/http.dart' as http;
 import 'package:jose/jose.dart';


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Remove the redirect to the end session endpoint on the signout method.

Did some research, since we already set the [preferEphemeral](https://pub.dev/documentation/flutter_web_auth/latest/flutter_web_auth/FlutterWebAuth/authenticate.html)  params to true.  login session was kept within the scope. 

Clean up the end-session redirect logic for now. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
@logto-io/eng @julian-hartl @JulianHartl 
