### PR TITLE
feat(dart): add get access token by refresh token method

### DIFF
--- a/lib/logto_core.dart
+++ b/lib/logto_core.dart
@@ -124,7 +124,7 @@ Uri generateSignInUri(
   };
 
   if (resources != null && resources.isNotEmpty) {
-    queryParameters.addAll({'resources': resources});
+    queryParameters.addAll({'resource': resources});
   }
 
   return addQueryParameters(signInUri, queryParameters);

--- a/lib/src/exceptions/logto_auth_exceptions.dart
+++ b/lib/src/exceptions/logto_auth_exceptions.dart
@@ -1,7 +1,8 @@
 enum LogtoAuthExceptions {
   callbackUriValidationError,
   idTokenValidationError,
-  authenticationError
+  authenticationError,
+  isLoadingError
 }
 
 class LogtoAuthException implements Exception {

--- a/lib/src/modules/token_storage.dart
+++ b/lib/src/modules/token_storage.dart
@@ -101,14 +101,16 @@ class TokenStorage {
   }
 
   Future<void> _deleteAccessToken(String accessTokenKey) async {
-    final tempAccessTokenMap = _accessTokenMap;
-    final value = tempAccessTokenMap?.remove(accessTokenKey);
+    final Map<String, AccessToken> tempAccessTokenMap =
+        Map.from(_accessTokenMap ?? {});
+
+    final value = tempAccessTokenMap.remove(accessTokenKey);
 
     // Do not update the storage if target accessToken does not exist
     if (value == null) return;
 
     // clean up the storage if is empty
-    if (tempAccessTokenMap == null || tempAccessTokenMap.isEmpty) {
+    if (tempAccessTokenMap.isEmpty) {
       await _storage.delete(key: _TokenStorageKeys.accessTokenKey);
       _accessTokenMap = null;
       return;

--- a/lib/src/modules/token_storage.dart
+++ b/lib/src/modules/token_storage.dart
@@ -93,7 +93,7 @@ class TokenStorage {
 
     // remove the access token if expired and return null
     if (accessToken?.isExpired == true) {
-      _deleteAccessToken(key);
+      await _deleteAccessToken(key);
       return null;
     }
 

--- a/lib/src/modules/token_storage.dart
+++ b/lib/src/modules/token_storage.dart
@@ -87,13 +87,35 @@ class TokenStorage {
       [String? resource, List<String>? scopes]) async {
     final key = _buildAccessTokenKey(resource, scopes);
 
-    if (_accessTokenMap != null) {
-      return _accessTokenMap![key];
+    _accessTokenMap ??= await _getAccessTokenMapFromStorage();
+
+    final accessToken = _accessTokenMap?[key];
+
+    // remove the access token if expired and return null
+    if (accessToken?.isExpired == true) {
+      _deleteAccessToken(key);
+      return null;
     }
 
-    _accessTokenMap = await _getAccessTokenMapFromStorage();
+    return accessToken;
+  }
 
-    return _accessTokenMap?[key];
+  Future<void> _deleteAccessToken(String accessTokenKey) async {
+    final tempAccessTokenMap = _accessTokenMap;
+    final value = tempAccessTokenMap?.remove(accessTokenKey);
+
+    // Do not update the storage if target accessToken does not exist
+    if (value == null) return;
+
+    // clean up the storage if is empty
+    if (tempAccessTokenMap == null || tempAccessTokenMap.isEmpty) {
+      await _storage.delete(key: _TokenStorageKeys.accessTokenKey);
+      _accessTokenMap = null;
+      return;
+    }
+
+    await _saveAccessTokenMapToStorage(tempAccessTokenMap);
+    _accessTokenMap = tempAccessTokenMap;
   }
 
   Future<void> _saveAccessTokenMapToStorage(

--- a/lib/src/modules/token_storage.dart
+++ b/lib/src/modules/token_storage.dart
@@ -53,16 +53,15 @@ class TokenStorage {
   }
 
   Future<void> setIdToken(IdToken? idToken) async {
-    _idToken = idToken;
-
     await _storage.write(
       key: _TokenStorageKeys.idTokenKey,
       value: _encodeIdToken(idToken),
     );
+
+    _idToken = idToken;
   }
 
-  static String _buildAccessTokenKey(String? resource,
-          [List<String>? scopes]) =>
+  static String buildAccessTokenKey(String? resource, [List<String>? scopes]) =>
       "${_encodeScopes(scopes)}@${resource ?? ''}";
 
   Future<Map<String, AccessToken>?> _getAccessTokenMapFromStorage() async {
@@ -85,7 +84,7 @@ class TokenStorage {
 
   Future<AccessToken?> getAccessToken(
       [String? resource, List<String>? scopes]) async {
-    final key = _buildAccessTokenKey(resource, scopes);
+    final key = buildAccessTokenKey(resource, scopes);
 
     _accessTokenMap ??= await _getAccessTokenMapFromStorage();
 
@@ -130,17 +129,20 @@ class TokenStorage {
 
   Future<void> setAccessToken(String accessToken,
       {String? resource, List<String>? scopes, required int expiresIn}) async {
-    final key = _buildAccessTokenKey(resource, scopes);
+    final key = buildAccessTokenKey(resource, scopes);
+
+    // load current accessTokenMap
+    final currentAccessTokenMap =
+        _accessTokenMap ?? await _getAccessTokenMapFromStorage() ?? {};
 
     final Map<String, AccessToken> newAccessTokenMap =
-        Map.from(_accessTokenMap ?? {});
+        Map.from(currentAccessTokenMap);
 
     newAccessTokenMap.addAll({
       key: AccessToken(
           token: accessToken,
           scope: _encodeScopes(scopes),
-
-          /// convert the expireAt to standard utc time
+          // convert the expireAt to standard utc time
           expiresAt: DateTime.now().add(Duration(seconds: expiresIn)).toUtc())
     });
 
@@ -160,12 +162,12 @@ class TokenStorage {
   }
 
   Future<void> setRefreshToken(String? refreshToken) async {
-    _refreshToken = refreshToken;
-
     await _storage.write(
       key: _TokenStorageKeys.refreshTokenKey,
       value: refreshToken,
     );
+
+    _refreshToken = refreshToken;
   }
 
   /// Initial token response saving

--- a/test/logto_core_test.dart
+++ b/test/logto_core_test.dart
@@ -30,6 +30,7 @@ void main() {
         clientId: clientId,
         redirectUri: redirectUri,
         codeChallenge: codeChallenge,
+        resources: ['http://foo.api'],
         state: state);
 
     expect(signInUri.scheme, 'http');
@@ -37,6 +38,8 @@ void main() {
     expect(signInUri.queryParameters, containsPair('client_id', clientId));
     expect(signInUri.queryParameters,
         containsPair('redirect_uri', 'http://foo.app.io'));
+    expect(
+        signInUri.queryParameters, containsPair('resource', 'http://foo.api'));
     expect(signInUri.queryParameters,
         containsPair('code_challenge', codeChallenge));
     expect(signInUri.queryParameters,

--- a/test/modules/token_storage_test.dart
+++ b/test/modules/token_storage_test.dart
@@ -59,12 +59,19 @@ void main() {
           equals(tokenStorage?.expiresAt.toIso8601String()));
     });
 
-    test('access token should expires properly', () async {
-      await sut.setAccessToken(accessToken, expiresIn: 1);
+    test('should remove the expired access token and return null', () async {
+      await sut.setAccessToken(accessToken,
+          resource: resource, scopes: scope.split(' '), expiresIn: 1);
+
+      final tokenStorage = await sut.getAccessToken(resource, scope.split(' '));
+      expect(tokenStorage?.token, accessToken);
 
       await Future.delayed(const Duration(seconds: 2), () async {
-        final token = await sut.getAccessToken();
-        expect(token?.isExpired, true);
+        final token = await sut.getAccessToken(resource, scope.split(' '));
+        expect(token, isNull);
+        expect(
+            await storageStrategy.read(key: _TokenStorageKeys.accessTokenKey),
+            isNull);
       });
     });
 


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add get access token by refresh token method

- get Access token from the storage by resource
- if no access token is found, claim a new access token by calling the getAccessTokenByRefreshToken request
- Add a promise cache to avoid the racing condition of getAccessToken request
- Fix token storage bug. For all async storage updates, should update the local/inMemory cache value after a successful update of persistent storage
- Fix token storage bug.  Set new access token should load from the persistent storage if local/inMemory cache value is null


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
@logto-io/mandatory-reviewers @logto-io/eng  cc: @julian-hartl 
