### PR TITLE
feat(dart): add interactionMode props to the signIn method

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:logto_dart_sdk/logto_client.dart';
 import 'package:http/http.dart' as http;
+import 'package:logto_dart_sdk/logto_core.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:logto_dart_sdk/logto_client.dart';
 import 'package:http/http.dart' as http;
-import 'package:logto_dart_sdk/logto_core.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();

--- a/lib/logto_client.dart
+++ b/lib/logto_client.dart
@@ -12,6 +12,7 @@ import '/src/modules/token_storage.dart';
 import '/src/utilities/constants.dart';
 import '/src/utilities/utils.dart' as utils;
 import 'logto_core.dart' as logto_core;
+import 'logto_core.dart';
 
 export '/src/interfaces/logto_config.dart';
 
@@ -148,7 +149,8 @@ class LogtoClient {
     }
   }
 
-  Future<void> signIn(String redirectUri) async {
+  Future<void> signIn(String redirectUri,
+      [InteractionMode? interactionMode]) async {
     if (_loading) {
       throw LogtoAuthException(
           LogtoAuthExceptions.isLoadingError, 'Already signing in...');
@@ -171,6 +173,7 @@ class LogtoClient {
         state: _state,
         resources: config.resources,
         scopes: config.scopes,
+        interactionMode: interactionMode,
       );
       String? callbackUri;
 

--- a/lib/logto_client.dart
+++ b/lib/logto_client.dart
@@ -70,23 +70,20 @@ class LogtoClient {
     return _oidcConfig!;
   }
 
-  Future<AccessToken?> getAccessToken(
-      {String? resource, List<String>? scopes}) async {
+  Future<AccessToken?> getAccessToken({String? resource}) async {
     final accessToken = await _tokenStorage.getAccessToken(resource);
 
     if (accessToken != null) {
       return accessToken;
     }
 
-    final token =
-        await _getAccessTokenByRefreshToken(resource: resource, scopes: scopes);
+    final token = await _getAccessTokenByRefreshToken(resource);
 
     return token;
   }
 
   // RBAC are not supported currently, no resource specific scopes are needed
-  Future<AccessToken?> _getAccessTokenByRefreshToken(
-      {String? resource, List<String>? scopes}) async {
+  Future<AccessToken?> _getAccessTokenByRefreshToken(String? resource) async {
     final refreshToken = await _tokenStorage.refreshToken;
 
     if (refreshToken == null) {
@@ -100,19 +97,17 @@ class LogtoClient {
       final oidcConfig = await _getOidcConfig(httpClient);
 
       final response = await logto_core.fetchTokenByRefreshToken(
-          httpClient: httpClient,
-          tokenEndPoint: oidcConfig.tokenEndpoint,
-          clientId: config.appId,
-          refreshToken: refreshToken,
-          resource: resource,
-          scopes: scopes);
+        httpClient: httpClient,
+        tokenEndPoint: oidcConfig.tokenEndpoint,
+        clientId: config.appId,
+        refreshToken: refreshToken,
+        resource: resource,
+      );
 
-      final responseScopes = response.scope.split(' ');
+      final scopes = response.scope.split(' ');
 
       await _tokenStorage.setAccessToken(response.accessToken,
-          expiresIn: response.expiresIn,
-          resource: resource,
-          scopes: responseScopes);
+          expiresIn: response.expiresIn, resource: resource, scopes: scopes);
 
       // renew refresh token
       await _tokenStorage.setRefreshToken(response.refreshToken);
@@ -124,7 +119,7 @@ class LogtoClient {
         await _tokenStorage.setIdToken(idToken);
       }
 
-      return await _tokenStorage.getAccessToken(resource, responseScopes);
+      return await _tokenStorage.getAccessToken(resource, scopes);
     } finally {
       if (_httpClient == null) httpClient.close();
     }

--- a/lib/logto_core.dart
+++ b/lib/logto_core.dart
@@ -12,6 +12,21 @@ const String _responseType = 'code';
 const String _prompt = 'consent';
 const String _requestContentType = 'application/x-www-form-urlencoded';
 
+enum InteractionMode { signIn, signUp }
+
+extension InteractionModeExtension on InteractionMode {
+  String get value {
+    switch (this) {
+      case InteractionMode.signIn:
+        return 'signIn';
+      case InteractionMode.signUp:
+        return 'signUp';
+      default:
+        throw Exception("Invalid value");
+    }
+  }
+}
+
 Future<OidcProviderConfig> fetchOidcConfig(
     http.Client httpClient, String endpoint) async {
   final response = await httpClient.get(Uri.parse(endpoint));
@@ -109,6 +124,7 @@ Uri generateSignInUri(
     required String state,
     List<String>? scopes,
     List<String>? resources,
+    InteractionMode? interactionMode,
     String prompt = _prompt}) {
   var signInUri = Uri.parse(authorizationEndpoint);
 
@@ -125,6 +141,11 @@ Uri generateSignInUri(
 
   if (resources != null && resources.isNotEmpty) {
     queryParameters.addAll({'resource': resources});
+  }
+
+  if (interactionMode != null) {
+    // need to align with the backend OIDC params name
+    queryParameters.addAll({'interaction_mode': interactionMode.value});
   }
 
   return addQueryParameters(signInUri, queryParameters);

--- a/test/logto_core_test.dart
+++ b/test/logto_core_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
+import 'package:logto_dart_sdk/logto_core.dart';
 import 'package:nock/nock.dart';
 
 import 'package:logto_dart_sdk/logto_core.dart' as logto_core;
@@ -24,6 +25,7 @@ void main() {
     var redirectUri = 'http://foo.app.io';
     const String codeChallenge = 'foo_code_challenge';
     const String state = 'foo_state';
+    const InteractionMode interactionMode = InteractionMode.signUp;
 
     var signInUri = logto_core.generateSignInUri(
         authorizationEndpoint: authorizationEndpoint,
@@ -31,7 +33,8 @@ void main() {
         redirectUri: redirectUri,
         codeChallenge: codeChallenge,
         resources: ['http://foo.api'],
-        state: state);
+        state: state,
+        interactionMode: interactionMode);
 
     expect(signInUri.scheme, 'http');
     expect(signInUri.host, 'foo.com');
@@ -49,6 +52,8 @@ void main() {
         containsPair('scope', reservedScopes.join(' ')));
     expect(signInUri.queryParameters, containsPair('response_type', 'code'));
     expect(signInUri.queryParameters, containsPair('prompt', 'consent'));
+    expect(
+        signInUri.queryParameters, containsPair('interaction_mode', 'signUp'));
   });
 
   test('Generate SignOut Uri', () {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Allow users to specify an interaction mode to initiate a register first sign-in experience.

- signUp: register first
- signIn or null: sign-in first

This PR also removed the scope props from getAccessToken method. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
UT updated

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [x] unit tests
- [ ] integration tests
- [ ] docs

OR

- [ ] This PR is not applicable for the checklist
