### PR TITLE
fix: fix getUserInfo not_authenticated bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,3 +58,11 @@ Upgrade to dart 3.0.0
 - Fix the `UserInfo` abstract class used as mixin incompatibility issue
 - SDK now supports Dart ^3.0.0
 - < 3.0.0 users please use the previous version of the SDK
+
+## 2.0.1
+
+Bug fix
+
+Issue: `LogtoClient.getUserInfo` method throws an `not authenticated` error when the initial access token is expired.
+Expected behavior: The method should refresh the access token and return the user info properly.
+Fix: Always get the access token by calling `LogtoClient.getAccessToken`, which will refresh the token automatically if it's expired.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -310,7 +310,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.0"
+    version: "2.0.0"
   matcher:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -310,7 +310,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.1"
   matcher:
     dependency: transitive
     description:

--- a/lib/logto_client.dart
+++ b/lib/logto_client.dart
@@ -11,9 +11,9 @@ import '/src/modules/token_storage.dart';
 import '/src/utilities/utils.dart' as utils;
 import 'logto_core.dart' as logto_core;
 
+export '/src/exceptions/logto_auth_exceptions.dart';
 export '/src/interfaces/logto_interfaces.dart';
 export '/src/utilities/constants.dart';
-export '/src/exceptions/logto_auth_exceptions.dart';
 
 /**
  * LogtoClient
@@ -306,7 +306,7 @@ class LogtoClient {
     try {
       final oidcConfig = await _getOidcConfig(httpClient);
 
-      final accessToken = await _tokenStorage.getAccessToken();
+      final accessToken = await getAccessToken();
 
       if (accessToken == null) {
         throw LogtoAuthException(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: logto_dart_sdk
 description: Logto's Flutter SDK packages.
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/logto-io/dart
 documentation: https://docs.logto.io/sdk/flutter/
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Bug fix for the [issue](https://github.com/logto-io/logto/issues/5970) 

- Issue: `LogtoClient.getUserInfo` method throws an `not authenticated` error when the initial access token is expired.
- Expected behavior: The method should refresh the access token and return the user info properly.
- Fix: Always get the access token by calling `LogtoClient.getAccessToken`, which will refresh the token automatically if it's expired.
 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally with simulator

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
