### PR TITLE
Added directSignIn parameter to client `signIn` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,3 +66,9 @@ Bug fix
 Issue: `LogtoClient.getUserInfo` method throws an `not authenticated` error when the initial access token is expired.
 Expected behavior: The method should refresh the access token and return the user info properly.
 Fix: Always get the access token by calling `LogtoClient.getAccessToken`, which will refresh the token automatically if it's expired.
+
+## 2.0.2
+
+### Features
+
+- Added directSignIn parameter to client `signIn` method. This parameter allows you to skip the first screen and invoke the sign-in process directly. ** Introduces a breaking change by adding optional named method parameters **

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -288,6 +288,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.9.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.4"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -315,26 +339,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -371,10 +395,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   path_provider:
     dependency: transitive
     description:
@@ -568,26 +592,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: a1f7595805820fcc05e5c52e3a231aedd0b72972cb333e8c738a8b1239448b6f
+      sha256: "7ee446762c2c50b3bd4ea96fe13ffac69919352bd3b4b17bac3f3465edc58073"
       url: "https://pub.dev"
     source: hosted
-    version: "1.24.9"
+    version: "1.25.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: a757b14fc47507060a162cc2530d9a4a2f92f5100a952c7443b5cad5ef5b106a
+      sha256: "2bc4b4ecddd75309300d8096f781c0e3280ca1ef85beda558d33fcbedc2eead4"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.9"
+    version: "0.6.0"
   typed_data:
     dependency: transitive
     description:
@@ -608,10 +632,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
   watcher:
     dependency: transitive
     description:
@@ -677,5 +701,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.2.3 <4.0.0"
-  flutter: ">=3.16.6"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/logto_client.dart
+++ b/lib/logto_client.dart
@@ -33,6 +33,7 @@ export '/src/utilities/constants.dart';
  * );
  * 
  * final logtoClient = LogtoClient(config);
+ * ```
  */
 class LogtoClient {
   final LogtoConfig config;
@@ -187,8 +188,11 @@ class LogtoClient {
   }
 
   // Sign in using the PKCE flow.
-  Future<void> signIn(String redirectUri,
-      [logto_core.InteractionMode? interactionMode]) async {
+  Future<void> signIn(
+    String redirectUri, {
+    logto_core.InteractionMode? interactionMode,
+    String? directSignIn,
+  }) async {
     if (_loading) {
       throw LogtoAuthException(
           LogtoAuthExceptions.isLoadingError, 'Already signing in...');
@@ -212,6 +216,7 @@ class LogtoClient {
         resources: config.resources,
         scopes: config.scopes,
         interactionMode: interactionMode,
+        directSignIn: directSignIn,
       );
 
       final redirectUriScheme = Uri.parse(redirectUri).scheme;

--- a/lib/logto_core.dart
+++ b/lib/logto_core.dart
@@ -167,7 +167,14 @@ Uri generateSignInUri(
     List<String>? scopes,
     List<String>? resources,
     InteractionMode? interactionMode,
+    String? directSignIn,
     String prompt = _prompt}) {
+  assert(
+    isValidDirectSignInFormat(directSignIn),
+    'Invalid format for directSignIn: $directSignIn, '
+    'expected one of `social:{connector}` or `sso:{connector}`',
+  );
+
   var signInUri = Uri.parse(authorizationEndpoint);
 
   Map<String, dynamic> queryParameters = {
@@ -178,6 +185,7 @@ Uri generateSignInUri(
     'state': state,
     'scope': withReservedScopes(scopes ?? []).join(' '),
     'response_type': _responseType,
+    'direct_sign_in': directSignIn,
     'prompt': prompt,
   };
 
@@ -216,6 +224,13 @@ Uri generateSignOutUri({
     'client_id': clientId,
     'post_logout_redirect_uri': postLogoutRedirectUri?.toString()
   });
+}
+
+bool isValidDirectSignInFormat(String? directSignIn) {
+  if (directSignIn == null) return true;
+
+  RegExp regex = RegExp(r'^(social|sso):[a-zA-Z0-9]+$');
+  return regex.hasMatch(directSignIn);
 }
 
 /**

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: logto_dart_sdk
 description: Logto's Flutter SDK packages.
-version: 2.0.1
+version: 2.0.2
 homepage: https://github.com/logto-io/dart
 documentation: https://docs.logto.io/sdk/flutter/
 

--- a/test/logto_core_test.dart
+++ b/test/logto_core_test.dart
@@ -77,6 +77,96 @@ void main() {
             ['http://foo.api', LogtoReservedResource.organization.value]));
   });
 
+  test('Generate SignIn Uri with direct sign in specified', () {
+    const String authorizationEndpoint = 'http://foo.com';
+    const clientId = 'foo_client';
+    var redirectUri = 'http://foo.app.io';
+    const String codeChallenge = 'foo_code_challenge';
+    const String state = 'foo_state';
+    const String directSignIn = 'social:connector';
+
+    var signInUri = logto_core.generateSignInUri(
+        authorizationEndpoint: authorizationEndpoint,
+        clientId: clientId,
+        redirectUri: redirectUri,
+        codeChallenge: codeChallenge,
+        resources: ['http://foo.api'],
+        state: state,
+        directSignIn: directSignIn);
+
+    expect(signInUri.queryParameters,
+        containsPair('direct_sign_in', directSignIn));
+  });
+
+  test('SignIn Uri with direct sign starting with `social:` passes validation',
+      () {
+    const String authorizationEndpoint = 'http://foo.com';
+    const clientId = 'foo_client';
+    var redirectUri = 'http://foo.app.io';
+    const String codeChallenge = 'foo_code_challenge';
+    const String state = 'foo_state';
+    const String directSignIn = 'social:connector';
+
+    var signInUri = logto_core.generateSignInUri(
+        authorizationEndpoint: authorizationEndpoint,
+        clientId: clientId,
+        redirectUri: redirectUri,
+        codeChallenge: codeChallenge,
+        resources: ['http://foo.api'],
+        state: state,
+        directSignIn: directSignIn);
+
+    expect(signInUri.queryParameters,
+        containsPair('direct_sign_in', directSignIn));
+  });
+
+  test('SignIn Uri with direct sign starting with `sso:` passes validation',
+      () {
+    const String authorizationEndpoint = 'http://foo.com';
+    const clientId = 'foo_client';
+    var redirectUri = 'http://foo.app.io';
+    const String codeChallenge = 'foo_code_challenge';
+    const String state = 'foo_state';
+    const String directSignIn = 'sso:connector';
+
+    var signInUri = logto_core.generateSignInUri(
+        authorizationEndpoint: authorizationEndpoint,
+        clientId: clientId,
+        redirectUri: redirectUri,
+        codeChallenge: codeChallenge,
+        resources: ['http://foo.api'],
+        state: state,
+        directSignIn: directSignIn);
+
+    expect(signInUri.queryParameters,
+        containsPair('direct_sign_in', directSignIn));
+  });
+
+  test('SignIn Uri with direct sign starting with `wrong:` fails validation',
+      () {
+    const String authorizationEndpoint = 'http://foo.com';
+    const clientId = 'foo_client';
+    var redirectUri = 'http://foo.app.io';
+    const String codeChallenge = 'foo_code_challenge';
+    const String state = 'foo_state';
+    const String directSignIn = 'wrong:connector';
+
+    expect(
+        () => logto_core.generateSignInUri(
+            authorizationEndpoint: authorizationEndpoint,
+            clientId: clientId,
+            redirectUri: redirectUri,
+            codeChallenge: codeChallenge,
+            resources: ['http://foo.api'],
+            state: state,
+            directSignIn: directSignIn),
+        throwsA(predicate((e) =>
+            e is AssertionError &&
+            e.message ==
+                'Invalid format for directSignIn: $directSignIn, '
+                    'expected one of `social:{connector}` or `sso:{connector}`')));
+  });
+
   test('Generate SignOut Uri', () {
     const String endSessionEndpoint = 'https://foo.com';
     const String clientId = 'foo_client';


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
Added directSignIn parameter to client `signIn` method. This parameter allows you to skip the first screen and invoke the sign-in process directly. ** Introduces a breaking change by adding optional named method parameters **


<!-- MANDATORY -->
## Testing
Unit and manual testing


<!-- MANDATORY -->
## Checklist

- [x] `.changelog`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
