### PR TITLE
fix(dart): idToken claims key fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,3 +66,16 @@ Bug fix
 Issue: `LogtoClient.getUserInfo` method throws an `not authenticated` error when the initial access token is expired.
 Expected behavior: The method should refresh the access token and return the user info properly.
 Fix: Always get the access token by calling `LogtoClient.getAccessToken`, which will refresh the token automatically if it's expired.
+
+## 2.0.2
+
+Bug fix
+
+Fix the IdToken claims key parsing issue:
+
+- `avatar` key is now `picture`
+- `phone` key is now `phone_number`
+- `phone_verified` key is now `phone_number_verified`
+
+Previous key mapping values are always empty as they are not available in the IdToken claims.
+This fix update the key mapping to the correct values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,11 +71,11 @@ Fix: Always get the access token by calling `LogtoClient.getAccessToken`, which 
 
 Bug fix
 
-Fix the IdToken claims key parsing issue:
+Fix the `OpenIdClaims` class key parsing issue:
 
-- `avatar` key is now `picture`
-- `phone` key is now `phone_number`
-- `phone_verified` key is now `phone_number_verified`
+- `avatar` key is now `picture` mapped from the `picture` key in the token claims
+- `phone` key is now `phoneNumber` mapped from the `phone_number` key in the token claims
+- `phoneVerified` key is now `phoneNumberVerified` mapped from the `phone_number_verified` key in the token claims
 
 Previous key mapping values are always empty as they are not available in the IdToken claims.
 This fix update the key mapping to the correct values.

--- a/lib/src/modules/id_token.dart
+++ b/lib/src/modules/id_token.dart
@@ -13,19 +13,19 @@ abstract mixin class UserInfo implements JsonObject {
   String? get username => this['username'];
 
   /// URL of the user's profile picture.
-  String? get avatar => this['avatar'];
+  String? get picture => this['picture'];
 
   /// Email address of the user.
   String? get email => this['email'];
 
   /// Phone number of the user.
-  String? get phone => this['phone'];
+  String? get phoneNumber => this['phone_number'];
 
   /// Whether the user's email address has been verified.
   String? get emailVerified => this['email_verified'];
 
   /// Whether the user's phone number has been verified.
-  String? get phoneVerified => this['phone_verified'];
+  String? get phoneNumberVerified => this['phone_number_verified'];
 
   /// Roles that the user has for API resources.
   List<String>? get roles => this['roles'];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: logto_dart_sdk
 description: Logto's Flutter SDK packages.
-version: 2.0.1
+version: 2.0.2
 homepage: https://github.com/logto-io/dart
 documentation: https://docs.logto.io/sdk/flutter/
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Fix the `OpenIdClaims` class key parsing issue:

- `avatar` key is now `picture` mapped from the `picture` key in the token claims
- `phone` key is now `phoneNumber` mapped from the `phone_number` key in the token claims
- `phoneVerified` key is now `phoneNumberVerified` mapped from the `phone_number_verified` key in the token claims

Previous key mapping values are always empty as they are unavailable in the IdToken claims.
This fix updates the key mapping to the correct values.

related issue: #63 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
