### PR TITLE
fix(dart): fix getAccessToken always null bug

### DIFF
--- a/lib/logto_client.dart
+++ b/lib/logto_client.dart
@@ -161,7 +161,7 @@ class LogtoClient {
       }
 
       return await _tokenStorage.getAccessToken(
-          resource: resource, organizationId: organizationId, scopes: scopes);
+          resource: resource, organizationId: organizationId);
     } finally {
       if (_httpClient == null) httpClient.close();
     }
@@ -257,7 +257,8 @@ class LogtoClient {
         idToken: idToken,
         accessToken: tokenResponse.accessToken,
         refreshToken: tokenResponse.refreshToken,
-        expiresIn: tokenResponse.expiresIn);
+        expiresIn: tokenResponse.expiresIn,
+        scopes: tokenResponse.scope.split(' '));
   }
 
   // Sign out the user.

--- a/lib/src/modules/token_storage.dart
+++ b/lib/src/modules/token_storage.dart
@@ -92,11 +92,10 @@ class TokenStorage {
 
   Future<AccessToken?> getAccessToken({
     String? resource,
-    List<String>? scopes,
     String? organizationId,
   }) async {
-    final key = buildAccessTokenKey(
-        resource: resource, scopes: scopes, organizationId: organizationId);
+    final key =
+        buildAccessTokenKey(resource: resource, organizationId: organizationId);
 
     _accessTokenMap ??= await _getAccessTokenMapFromStorage();
 
@@ -145,7 +144,9 @@ class TokenStorage {
       String? organizationId,
       required int expiresIn}) async {
     final key = buildAccessTokenKey(
-        resource: resource, organizationId: organizationId, scopes: scopes);
+      resource: resource,
+      organizationId: organizationId,
+    );
 
     // load current accessTokenMap
     final currentAccessTokenMap =
@@ -197,10 +198,11 @@ class TokenStorage {
     required IdToken idToken,
     required String accessToken,
     String? refreshToken,
+    List<String>? scopes,
     required int expiresIn,
   }) async {
     await Future.wait([
-      setAccessToken(accessToken, expiresIn: expiresIn),
+      setAccessToken(accessToken, expiresIn: expiresIn, scopes: scopes),
       setIdToken(idToken),
       setRefreshToken(refreshToken),
     ]);

--- a/test/modules/token_storage_test.dart
+++ b/test/modules/token_storage_test.dart
@@ -36,13 +36,14 @@ void main() {
     });
     test('should set access token locally and persist it', () async {
       await sut.setAccessToken(accessToken,
-          resource: resource, scopes: scope.split(' '), expiresIn: 1);
+          resource: resource, scopes: scope.split(' '), expiresIn: 1000);
 
       final nullToken = await sut.getAccessToken();
       expect(nullToken, isNull);
 
       final tokenStorage = await sut.getAccessToken(
-          resource: resource, scopes: scope.split(' '));
+        resource: resource,
+      );
 
       expect(tokenStorage?.token, accessToken);
       // scope should be sorted
@@ -53,7 +54,7 @@ void main() {
           await storageStrategy.read(key: _TokenStorageKeys.accessTokenKey);
 
       final tokenMap = jsonDecode(persistedStorageAccessToken ?? '{}');
-      final Map<String, dynamic> token = tokenMap['email profile@/api/foo'];
+      final Map<String, dynamic> token = tokenMap['@/api/foo'];
 
       expect(token['token'], tokenStorage?.token);
       expect(token['scope'], tokenStorage?.scope);
@@ -71,8 +72,8 @@ void main() {
       final nullToken = await sut.getAccessToken();
       expect(nullToken, isNull);
 
-      final tokenStorage = await sut.getAccessToken(
-          scopes: scope.split(' '), organizationId: organizationId);
+      final tokenStorage =
+          await sut.getAccessToken(organizationId: organizationId);
 
       expect(tokenStorage?.token, accessToken);
       // scope should be sorted
@@ -84,8 +85,7 @@ void main() {
 
       final tokenMap = jsonDecode(persistedStorageAccessToken ?? '{}');
 
-      final Map<String, dynamic> token =
-          tokenMap['email profile@#$organizationId'];
+      final Map<String, dynamic> token = tokenMap['@#$organizationId'];
 
       expect(token['token'], tokenStorage?.token);
       expect(token['scope'], tokenStorage?.scope);
@@ -98,12 +98,12 @@ void main() {
           resource: resource, scopes: scope.split(' '), expiresIn: 1);
 
       final tokenStorage = await sut.getAccessToken(
-          resource: resource, scopes: scope.split(' '));
+        resource: resource,
+      );
       expect(tokenStorage?.token, accessToken);
 
       await Future.delayed(const Duration(seconds: 2), () async {
-        final token = await sut.getAccessToken(
-            resource: resource, scopes: scope.split(' '));
+        final token = await sut.getAccessToken(resource: resource);
         expect(token, isNull);
         expect(
             await storageStrategy.read(key: _TokenStorageKeys.accessTokenKey),
@@ -159,10 +159,7 @@ void main() {
 
       await sut.clear();
 
-      expect(
-          await sut.getAccessToken(
-              resource: resource, scopes: scope.split(' ')),
-          null);
+      expect(await sut.getAccessToken(resource: resource), null);
       expect(await sut.refreshToken, null);
       expect(await sut.idToken, null);
 


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

This PR fixes the `getAccessToken` always fetches new access tokens using the refresh token bug. (See #65 for more details.)

### Root cause:

In the Logto Dart SDK, we store all token responses in local storage using a key-value format. Access tokens are stored based on their audience information and permissions. To generate a unique storage key for each access token, we use a combination of `resource`, `organization`, and `scopes`.

When calling the `client.getAccessToken` method, the SDK first checks local storage for a valid access token. If no related token is found or the token has expired, it requests a new one using the refresh token.

Currently, Logto does not support narrowing down scopes in token exchange requests, so scopes are not required in the `fetchTokenByRefreshToken` method. As a result, the `getAccessToken` method does not accept a `scopes` parameter and always attempts to read tokens from storage without considering `scopes`.

However, since the `setAccessToken` method builds storage keys with token scopes, and `getAccessToken` reads the storage without them, the method always returns `null`. This fallback triggers a new access token request every time.



### Fixes:
- Remove the `scopes` input parameter from the `_tokenStorage.buildAccessTokenKey` and `_tokenStorage.getAccessToken` method. The storage key should now be generated based only on `resource` and `organization`.
- Update the `_tokenStorage.save` call in the `client._handleSignInCallback` method to align with the `client._getTokenByRefresh` flow. Ensure that the initial access token scopes are also saved in the token storage.

Although token scopes should always be stored as part of the access token values, the storage key should be generated using only the `resource` and `organization`.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

UT updated

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
