### PR TITLE
feat: Add clearAccessToken method to LogtoClient

### DIFF
--- a/lib/logto_client.dart
+++ b/lib/logto_client.dart
@@ -189,6 +189,12 @@ class LogtoClient {
     }
   }
 
+  // Clear the access token by resource indicator or organizationId.
+  Future<void> clearAccessToken({String? resource, String? organizationId}) {
+    return _tokenStorage.deleteAccessToken(
+        resource: resource, organizationId: organizationId);
+  }
+
   // Sign in using the PKCE flow.
   Future<void> signIn(
     String redirectUri, {

--- a/lib/src/modules/token_storage.dart
+++ b/lib/src/modules/token_storage.dart
@@ -110,6 +110,16 @@ class TokenStorage {
     return accessToken;
   }
 
+  Future<void> deleteAccessToken({
+    String? resource,
+    String? organizationId,
+  }) async {
+    final key =
+        buildAccessTokenKey(resource: resource, organizationId: organizationId);
+
+    await _deleteAccessToken(key);
+  }
+
   Future<void> _deleteAccessToken(String accessTokenKey) async {
     final Map<String, AccessToken> tempAccessTokenMap =
         Map.from(_accessTokenMap ?? {});

--- a/test/modules/token_storage_test.dart
+++ b/test/modules/token_storage_test.dart
@@ -170,5 +170,20 @@ void main() {
       expect(
           await storageStrategy.read(key: _TokenStorageKeys.idTokenKey), null);
     });
+
+    test('deleteAccessToken method should delete persisted state', () async {
+      await sut.save(
+          idToken: idToken,
+          accessToken: accessToken,
+          refreshToken: refreshToken,
+          expiresIn: 1);
+
+      await sut.setAccessToken('tokenX', resource: resource, expiresIn: 3600);
+      expect(await sut.getAccessToken(resource: resource), isNotNull);
+
+      await sut.deleteAccessToken(resource: resource);
+
+      expect(await sut.getAccessToken(resource: resource), null);
+    });
   });
 }


### PR DESCRIPTION
## Summary

Add the method #clearAccessToken to the LogtoClient.
The JS SDKs also have a clearAccessToken method

## Testing

Simple unit test + ,anual testing.

## Checklist

- [ ] `.changeset`
- [X] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
